### PR TITLE
Make upload folder path changable

### DIFF
--- a/server/src/main/kotlin/org/filemat/server/common/util/utilFunctions.kt
+++ b/server/src/main/kotlin/org/filemat/server/common/util/utilFunctions.kt
@@ -321,7 +321,7 @@ private fun resolveNonExistent(rawPath: FilePath): Result<FilePath> {
     }
 
     val resolvedPath = if (nonExistentSuffix != null) resolvedPrefixPath.resolve(nonExistentSuffix) else resolvedPrefixPath
-    if (!State.App.followSymlinks && rawPath.path !== resolvedPath) {
+    if (!State.App.followSymlinks && rawPath.path != resolvedPath) {
         return Result.notFound()
     }
 

--- a/server/src/main/kotlin/org/filemat/server/module/admin/controller/AdminSettingsController.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/admin/controller/AdminSettingsController.kt
@@ -167,7 +167,7 @@ class AdminSettingsController(
         settingService.set_uploadFolderPath(user, path).let {
             if (it.rejected) return bad(it.error)
             if (it.isNotSuccessful) return internal(it.errorOrNull ?: "Failed to update upload folder path.")
-            return ok("ok")
+            return ok(it.value.pathString)
         }
     }
 

--- a/server/src/main/kotlin/org/filemat/server/module/file/controller/FolderController.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/controller/FolderController.kt
@@ -55,7 +55,7 @@ class FolderController(private val fileService: FileService) : AController() {
         val path = FilePath.of(rawPath)
 
         val result = let {
-            val (pathResult, pathHasSymlink) = resolvePath(path)
+            val pathResult = resolvePath(path)
             if (pathResult.isNotSuccessful) return@let pathResult.cast()
             val canonicalPath = pathResult.value
 

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/FileVisibilityService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/FileVisibilityService.kt
@@ -62,6 +62,8 @@ class FileVisibilityService(
             return "This file is blocked because it is marked as sensitive."
         }
 
+        if (!State.App.allowReadDataFolder && canonicalPath.startsWith(Props.dataFolderPath)) return "${Props.appName} data folder is blocked."
+
         val isForceHidden = hiddenFileTrie.getVisibility(canonicalPath.pathString)
         // isExposed is set to true because all folders in this list are forcefully hidden
         if (isForceHidden.isExposed == true) return "This file is blocked."

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/TusService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/TusService.kt
@@ -121,7 +121,7 @@ class TusService(
         val destinationParentPath = let {
             val parent = rawPath.path.parent.toString()
 
-            resolvePath(FilePath.of(parent)).let { (result, hasSymlink) ->
+            resolvePath(FilePath.of(parent)).let { result ->
                 if (result.notFound) {
                     response.respond(400, "The target folder does not exist.")
                     return false
@@ -199,7 +199,7 @@ class TusService(
 
         // Resolve the destination parent folder
         val destinationParent = let {
-            resolvePath(rawDestinationParent).let { (result, hadSymlink) ->
+            resolvePath(rawDestinationParent).let { result ->
                 if (result.isNotSuccessful) return result.cast()
                 result.value
             }

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/TusService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/TusService.kt
@@ -88,7 +88,7 @@ class TusService(
             }
 
             // Send TUS response
-           wrappedResponse.copyTo(response)
+            wrappedResponse.copyTo(response)
         }
     }
 

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/file/FileService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/file/FileService.kt
@@ -61,7 +61,6 @@ class FileService(
         user = user,
         rawPath = rawPath,
         existingCanonicalPath = existingCanonicalPath,
-        existingPathContainsSymlink = existingPathContainsSymlink,
         range = range,
         ignorePermissions = ignorePermissions,
     )
@@ -180,13 +179,13 @@ class FileService(
 
     // --- Utilities ---
 
-    fun resolvePathWithOptionalShare(path: FilePath, shareToken: String?, withPathContainsSymlink: Boolean): Pair<Result<FilePath>, Boolean> {
+    fun resolvePathWithOptionalShare(path: FilePath, shareToken: String?, withPathContainsSymlink: Boolean): Result<FilePath> {
         val sharedPath = if (shareToken != null) {
             entityService.getByShareToken(shareToken = shareToken)
                 .let {
-                    if (it.isNotSuccessful) return Pair(it.cast(), false)
+                    if (it.isNotSuccessful) return it.cast()
 
-                    val sharePathStr = it.value.path ?: return Pair(Result.notFound(), false)
+                    val sharePathStr = it.value.path ?: return Result.notFound()
                     val sharePath = FilePath.of(sharePathStr)
                     val fullPath = sharePath.path.resolve(path.pathString.removePrefix("/"))
                     return@let FilePath.ofAlreadyNormalized(fullPath)
@@ -197,7 +196,6 @@ class FileService(
     }
 
     fun resolvePathWithOptionalShare(path: FilePath, shareToken: String?): Result<FilePath> {
-        val result = resolvePathWithOptionalShare(path, shareToken, true)
-        return result.first
+        return resolvePathWithOptionalShare(path, shareToken, true)
     }
 }

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileContentService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileContentService.kt
@@ -55,27 +55,6 @@ class FileContentService(
             path.value
         }
 
-        // Return content of symlink file itself
-        // if following symlinks is disabled
-//        if (pathContainsSymlink) {
-//            if (!ignorePermissions) {
-//                fileService.isAllowedToAccessFile(user, rawPath).let {
-//                    if (it.isNotSuccessful) return it.cast()
-//                }
-//            }
-//
-//            if (Files.isSymbolicLink(rawPath.path)) {
-//                // stream the link itself
-//                return try {
-//                    Result.ok(Files.readSymbolicLink(rawPath.path).toString().toByteArray().inputStream())
-//                } catch (e: Exception) {
-//                    Result.error("Failed to read the symlink target path.")
-//                }
-//            } else {
-//                return Result.notFound()
-//            }
-//        }
-
         if (!ignorePermissions) {
             fileService.isAllowedToAccessFile(user, canonicalPath).let {
                 if (it.isNotSuccessful) return it.cast()

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileCopyService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileCopyService.kt
@@ -24,7 +24,7 @@ class FileCopyService(private val fileService: FileService, private val filesyst
 
         // Resolve the copied path
         val canonicalPath: FilePath = resolvePath(rawPath)
-            .let { (result: Result<FilePath>, pathHasSymlink: Boolean) ->
+            .let { result: Result<FilePath> ->
                 if (result.notFound) return Result.reject("Copied file was not found.")
                 if (result.isNotSuccessful) return result.cast()
                 result.value
@@ -36,7 +36,7 @@ class FileCopyService(private val fileService: FileService, private val filesyst
 
         // Resolve parent of destination path
         val canonicalParentDestinationPath: FilePath = resolvePath(rawParentDestinationPath)
-            .let { (result: Result<FilePath>, pathHasSymlink: Boolean) ->
+            .let { result: Result<FilePath> ->
                 if (result.notFound) return Result.reject("Destination folder was not found.")
                 if (result.isNotSuccessful) return result.cast()
                 result.value

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileDeletionService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileDeletionService.kt
@@ -25,7 +25,7 @@ class FileDeletionService(
         val canonicalPath = if (isSymlink) {
             rawPath
         } else {
-            resolvePath(rawPath).let { (canonicalResult, pathHasSymlink) ->
+            resolvePath(rawPath).let { canonicalResult ->
                 if (canonicalResult.isNotSuccessful) return canonicalResult.cast()
                 canonicalResult.value
             }

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileMetadataService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileMetadataService.kt
@@ -33,7 +33,7 @@ class FileMetadataService(
      * if file is a folder, also returns entries
      */
     fun getFileOrFolderEntries(user: Principal, rawPath: FilePath, foldersOnly: Boolean = false): Result<Pair<FullFileMetadata, List<FullFileMetadata>?>> {
-        val (pathResult, pathHasSymlink) = resolvePath(rawPath)
+        val pathResult = resolvePath(rawPath)
         if (pathResult.isNotSuccessful) return pathResult.cast()
         val canonicalPath = pathResult.value
 
@@ -85,7 +85,7 @@ class FileMetadataService(
         val rawSharePath = FilePath.of(entity.path)
 
         // Resolve entity path
-        val (canonicalSharePathResult, parentPathHasSymlink) = resolvePath(rawSharePath)
+        val canonicalSharePathResult = resolvePath(rawSharePath)
         if (canonicalSharePathResult.isNotSuccessful) return canonicalSharePathResult.cast()
         val canonicalSharePath = canonicalSharePathResult.value
 
@@ -137,7 +137,7 @@ class FileMetadataService(
         val canonicalPath = if (isPathCanonical) {
             rawPath
         } else {
-            val (pathResult, pathHasSymlink) = resolvePath(rawPath)
+            val pathResult = resolvePath(rawPath)
             if (pathResult.isNotSuccessful) return pathResult.cast()
             pathResult.value
         }

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileMoveService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/file/component/FileMoveService.kt
@@ -5,21 +5,24 @@ import org.filemat.server.common.model.cast
 import org.filemat.server.common.util.resolvePath
 import org.filemat.server.module.auth.model.Principal
 import org.filemat.server.module.file.model.FilePath
-import org.filemat.server.module.file.service.EntityService
 import org.filemat.server.module.file.service.file.FileService
 import org.filemat.server.module.file.service.filesystem.FilesystemService
 import org.filemat.server.module.savedFile.SavedFileService
 import org.springframework.stereotype.Service
 
 @Service
-class FileMoveService(private val fileService: FileService, private val entityService: EntityService, private val savedFileService: SavedFileService, private val filesystemService: FilesystemService) {
+class FileMoveService(
+    private val fileService: FileService,
+    private val savedFileService: SavedFileService,
+    private val filesystemService: FilesystemService
+) {
 
     fun moveFile(user: Principal, rawPath: FilePath, rawDestinationPath: FilePath): Result<Unit> {
         // Resolve the target path
         val rawParent = FilePath.ofAlreadyNormalized(rawPath.path.parent)
 
         val sourceParent = resolvePath(rawParent)
-            .let { (canonicalResult, _) ->
+            .let { canonicalResult ->
                 if (canonicalResult.isNotSuccessful) return canonicalResult.cast()
                 canonicalResult.value
             }
@@ -34,7 +37,7 @@ class FileMoveService(private val fileService: FileService, private val entitySe
 
         // Resolve the target path
         val destinationParentPath = resolvePath(rawDestinationParentPath)
-            .let { (destinationParentPathResult, containsSymLink) ->
+            .let { destinationParentPathResult ->
                 if (destinationParentPathResult.isNotSuccessful) return destinationParentPathResult.cast()
                 destinationParentPathResult.value
             }
@@ -71,7 +74,7 @@ class FileMoveService(private val fileService: FileService, private val entitySe
      * Moves multiple files, returns inputted paths of successfully moved files
      */
     fun moveMultipleFiles(user: Principal, rawPaths: List<FilePath>, rawNewParentPath: FilePath): Result<List<FilePath>> {
-        val (canonicalResult, parentPathHasSymlink) = resolvePath(rawNewParentPath)
+        val canonicalResult = resolvePath(rawNewParentPath)
         if (canonicalResult.isNotSuccessful) return canonicalResult.cast()
         val newParentPath = canonicalResult.value
 

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/filesystem/FilesystemService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/filesystem/FilesystemService.kt
@@ -122,8 +122,12 @@ class FilesystemService(
      */
     fun exists(path: Path, followSymbolicLinks: Boolean) = if (followSymbolicLinks) path.exists() else path.exists(LinkOption.NOFOLLOW_LINKS)
 
-    fun isFolderEmpty(path: Path): Result<Boolean> {
+    fun isFolderEmpty(path: Path, ignoreEmpty: Boolean = false): Result<Boolean> {
         try {
+            if (ignoreEmpty) {
+                if (!Files.exists(path)) return Result.ok(true)
+            }
+
             if (!Files.isDirectory(path)) {
                 return Result.ok(false)
             }

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/filesystem/FilesystemService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/filesystem/FilesystemService.kt
@@ -42,10 +42,15 @@ class FilesystemService(
         }
     }
 
-    fun initializeTusService() {
-        tusFileService = TusFileUploadService()
-            .withUploadUri("/api/v1/file/upload")
-            .withStoragePath(State.App.uploadFolderPath)
+    fun initializeTusService(): Boolean {
+        try {
+            tusFileService = TusFileUploadService()
+                .withUploadUri("/api/v1/file/upload")
+                .withStoragePath(State.App.uploadFolderPath)
+            return true
+        } catch (e: Exception) {
+            return false
+        }
     }
 
     fun createFolder(folder: FilePath): Result<Unit> {

--- a/server/src/main/kotlin/org/filemat/server/module/file/service/filesystem/fileOperation/FilesystemCopyService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/file/service/filesystem/fileOperation/FilesystemCopyService.kt
@@ -130,7 +130,7 @@ class FilesystemCopyService(
         val isSymlink = if (copyResolvedSymlinks) Files.isSymbolicLink(currentSource) else null
 
         val resolvedPath = if (isSymlink == true) {
-            resolvePath(sourceFilePath).let { (result, _) ->
+            resolvePath(sourceFilePath).let { result ->
                 if (result.isNotSuccessful) return failedCount + 1
                 result.value
             }.also {

--- a/server/src/main/kotlin/org/filemat/server/module/permission/service/EntityPermissionService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/permission/service/EntityPermissionService.kt
@@ -2,7 +2,6 @@ package org.filemat.server.module.permission.service
 
 import com.github.f4b6a3.ulid.Ulid
 import com.github.f4b6a3.ulid.UlidCreator
-import org.filemat.server.common.State
 import org.filemat.server.common.model.Result
 import org.filemat.server.common.model.cast
 import org.filemat.server.common.model.toResult
@@ -132,7 +131,7 @@ class EntityPermissionService(
     ): Result<EntityPermission> {
         if (ignorePermissions == false && user == null || ignorePermissions == true && userId == null) return Result.reject("Unauthenticated")
 
-        val canonicalPath = existingCanonicalPath ?: resolvePath(rawPath).let { (result, hasSymlink) ->
+        val canonicalPath = existingCanonicalPath ?: resolvePath(rawPath).let { result ->
             if (result.isNotSuccessful) return result.cast()
             result.value
         }
@@ -269,7 +268,7 @@ class EntityPermissionService(
      * Returns list of permissions for an entity along with affected usernames
      */
     fun getEntityPermissions(user: Principal, rawPath: FilePath): Result<EntityPermissionMeta> {
-        val (resolveResult, hasSymlink) = resolvePath(rawPath)
+        val resolveResult = resolvePath(rawPath)
         val canonicalPath = resolveResult.let {
             if (it.isNotSuccessful) return Result.notFound()
             it.value

--- a/server/src/main/kotlin/org/filemat/server/module/savedFile/SavedFileService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/savedFile/SavedFileService.kt
@@ -159,7 +159,7 @@ class SavedFileService(
         val metaList = entries.mapNotNull {
             val rawPath = FilePath.of(it.path)
 
-            val (pathResult, pathHasSymlink) = resolvePath(rawPath)
+            val pathResult = resolvePath(rawPath)
             if (pathResult.isNotSuccessful) return@mapNotNull null
             val canonicalPath = pathResult.value
 

--- a/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
@@ -32,7 +32,7 @@ class SettingService(
 
     fun set_uploadFolderPath(user: Principal, rawNewPath: FilePath): Result<FilePath> {
         tusService.uploadLock.writeLock().withLock {
-            val newPath = resolvePath(rawNewPath, resolvePartial = true).let { (result, containsSymLink) ->
+            val newPath = resolvePath(rawNewPath, allowNonExistent = true).let { result ->
                 if (result.isNotSuccessful) return result.cast()
                 result.value
             }

--- a/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
@@ -38,7 +38,11 @@ class SettingService(
             }
             val oldPath = FilePath.of(State.App.uploadFolderPath)
 
-            filesystemService.isFolderEmpty(newPath.path, ignoreEmpty = true).let {
+            filesystemService.createFolder(rawNewPath).let {
+                if (it.isNotSuccessful) return it.cast()
+            }
+
+            filesystemService.isFolderEmpty(newPath.path).let {
                 if (it.isNotSuccessful) return it.cast()
                 if (it.value == false) return Result.reject("Upload folder must be empty.")
             }
@@ -82,7 +86,7 @@ class SettingService(
                 logService.info(
                     type = LogType.SYSTEM,
                     action = UserAction.UPDATE_UPLOAD_FOLDER_PATH,
-                    description = "Failed to move upload files to new upload folder..",
+                    description = "Failed to move upload files to new upload folder.",
                     message = str,
                     initiatorId = user.userId,
                 )

--- a/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
@@ -87,7 +87,7 @@ class SettingService(
                     initiatorId = user.userId,
                 )
 
-                return Result.error("Upload folder was changed. Failed to move ${failedMoves} ${plural("file", failedMoves.size)}. $tusMessage")
+                return Result.error("Upload folder was changed. Failed to move ${failedMoves.size} ${plural("file", failedMoves.size)}. $tusMessage")
             }
 
             if (tusMessage.isNotBlank()) return Result.error("Upload folder was changed. $tusMessage")

--- a/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/setting/service/SettingService.kt
@@ -57,7 +57,8 @@ class SettingService(
                 initiatorId = user.userId,
             )
 
-            filesystemService.initializeTusService()
+            val createdTusService = filesystemService.initializeTusService()
+            val tusMessage = if (createdTusService) "" else "Failed to start upload service."
 
             // Move files to new location
             val files = kotlin.runCatching {
@@ -86,9 +87,10 @@ class SettingService(
                     initiatorId = user.userId,
                 )
 
-                return Result.error("Upload folder was changed. Failed to move ${failedMoves} ${plural("file", failedMoves.size)}.")
+                return Result.error("Upload folder was changed. Failed to move ${failedMoves} ${plural("file", failedMoves.size)}. $tusMessage")
             }
 
+            if (tusMessage.isNotBlank()) return Result.error("Upload folder was changed. $tusMessage")
             return Result.ok(newPath)
         }
     }

--- a/server/src/main/kotlin/org/filemat/server/module/sharedFile/service/FileShareService.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/sharedFile/service/FileShareService.kt
@@ -193,7 +193,7 @@ class FileShareService(
         password: ArgonHash?,
         maxAge: Long?
     ): Result<FileShare> {
-        val (canonicalResult, pathHasSymlink) = resolvePath(rawPath)
+        val canonicalResult = resolvePath(rawPath)
         val canonicalPath = canonicalResult.let {
             if (it.isNotSuccessful) return canonicalResult.cast()
             it.value
@@ -280,7 +280,7 @@ class FileShareService(
     }
 
     fun getSharesByPath(principal: Principal, rawPath: FilePath): Result<List<FileShare>> {
-        val (canonicalResult, pathHasSymlink) = resolvePath(rawPath)
+        val canonicalResult = resolvePath(rawPath)
         val canonicalPath = canonicalResult.let {
             if (it.isNotSuccessful) return canonicalResult.cast()
             it.value
@@ -421,7 +421,7 @@ class FileShareService(
         val rawSharePath = FilePath.of(entity.path ?: return Result.notFound())
 
         // Resolve entity path
-        val (canonicalSharePathResult, parentPathHasSymlink) = resolvePath(rawSharePath)
+        val canonicalSharePathResult = resolvePath(rawSharePath)
         if (canonicalSharePathResult.isNotSuccessful) return canonicalSharePathResult.cast()
         val canonicalSharePath = canonicalSharePathResult.value
 

--- a/server/src/main/kotlin/org/filemat/server/module/user/model/UserAction.kt
+++ b/server/src/main/kotlin/org/filemat/server/module/user/model/UserAction.kt
@@ -66,7 +66,8 @@ enum class UserAction(val index: Int) {
     COPY_FILE(57),
     DUPLICATE_ENTITY(58),
     GENERATE_ADMIN_OTP(59),
-    UPDATE_HOME_FOLDER_PATH(60);
+    UPDATE_HOME_FOLDER_PATH(60),
+    UPDATE_UPLOAD_FOLDER_PATH(61);
 
     companion object {
         init {

--- a/web/src/lib/code/module/files.ts
+++ b/web/src/lib/code/module/files.ts
@@ -255,7 +255,7 @@ export function startTusUpload(file: File) {
         metadata: {
             path: targetPath,
         },
-        chunkSize: 5 * 1024 * 1024,
+        chunkSize: 3072 * 1024, // 3 MB chunk
         onAfterResponse: (response) => {
             // Get the actual uploaded filename from the server
             // If the file already exists, the server will add a number to the end of the filename

--- a/web/src/lib/code/util/codeUtil.svelte.ts
+++ b/web/src/lib/code/util/codeUtil.svelte.ts
@@ -240,7 +240,6 @@ export function toStatus(s: number): httpStatus {
     } else if (isServerDown(s)) {
         result = { ok: false, serverDown: true, failed: true, notFound: false, raw: s }
     } else if (s === 404) {
-        
         result = { ok: false, serverDown: false, failed: true, notFound: true, raw: s }
     } else {
         result = { ok: false, serverDown: false, failed: true, notFound: false, raw: s }

--- a/web/src/routes/(app)/settings/preferences/+page.svelte
+++ b/web/src/routes/(app)/settings/preferences/+page.svelte
@@ -16,7 +16,7 @@
 </script>
 
 
-<div class="page !h-fit settings-margin flex-col gap-8 xoverflow-y-auto">
+<div class="page !h-fit settings-margin flex-col gap-8">
     {@render settingCell(LoadPreviewsSetting)}
     {@render settingCell(DefaultPageSetting)}
     {@render settingCell(ClickToOpenFileSetting)}

--- a/web/src/routes/(app)/settings/preferences/_setting-components/HomeFolderPathSetting.svelte
+++ b/web/src/routes/(app)/settings/preferences/_setting-components/HomeFolderPathSetting.svelte
@@ -55,10 +55,10 @@
 
 
 
-<div class="flex flex-col gap-4">
+<div class="flex flex-col gap-4 w-full">
     <h3 class="font-medium">Home folder path</h3>
     
-    <input bind:value={pathInput} class="basic-input" placeholder="Home folder path">
+    <input bind:value={pathInput} class="basic-input min-w-[35rem] w-fit max-w-[min(100%,70rem)] field-sizing-content" placeholder="Home folder path">
 
     <div class="flex gap-4">
         <button
@@ -68,10 +68,9 @@
         >
             Save
         </button>
-        {#if pathInput !== auth.principal?.homeFolderPath}
+        {#if !isUnchanged}
             <button
                 on:click={cancel}
-                disabled={isUnchanged}
                 class="basic-button"
             >
                 Cancel

--- a/web/src/routes/(app)/settings/system/+page.svelte
+++ b/web/src/routes/(app)/settings/system/+page.svelte
@@ -14,9 +14,7 @@
 </script>
 
 
-<div class="page !h-fit settings-margin flex-col gap-8 xoverflow-y-auto">
-    <!-- <h2 class="text-lg font-medium">File Settings</h2> -->
-     
+<div class="page !h-fit settings-margin flex-col gap-8">
     {@render settingCell(UploadFolderPathSetting)}
     {@render settingCell(SymbolicLinksSetting)}
 

--- a/web/src/routes/(app)/settings/system/+page.svelte
+++ b/web/src/routes/(app)/settings/system/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
     import { uiState } from "$lib/code/stateObjects/uiState.svelte";
-    import { onMount } from "svelte";
+    import { onMount, type Component } from "svelte";
     import SymbolicLinksSetting from "./_setting-components/SymbolicLinksSetting.svelte";
     import ExposedFilesSetting from "./_setting-components/ExposedFilesSetting.svelte";
     import LogsSetting from "./_setting-components/LogsSetting.svelte";
+    import UploadFolderPathSetting from "./_setting-components/UploadFolderPathSetting.svelte";
 
     const title = "System Settings"
 
@@ -13,15 +14,19 @@
 </script>
 
 
-<div class="page settings-margin flex-col gap-8">
-    <h2 class="text-lg font-medium">File System Settings</h2>
-    <div class="flex flex-col gap-6 p-6 rounded-lg w-full bg-surface">
-        
-        <div class="flex flex-col gap-8 w-full">
-            <SymbolicLinksSetting></SymbolicLinksSetting>
-        </div>
-    </div>
+<div class="page !h-fit settings-margin flex-col gap-8 xoverflow-y-auto">
+    <!-- <h2 class="text-lg font-medium">File Settings</h2> -->
+     
+    {@render settingCell(UploadFolderPathSetting)}
+    {@render settingCell(SymbolicLinksSetting)}
 
     <ExposedFilesSetting></ExposedFilesSetting>
     <LogsSetting></LogsSetting>
+
 </div>
+
+{#snippet settingCell(Component: Component<any>)}
+    <div class="flex flex-col gap-6 p-6 rounded-lg w-full bg-surface">
+        <Component></Component>
+    </div>
+{/snippet}

--- a/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
+++ b/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
@@ -31,7 +31,7 @@
             const response = await safeFetch(`/api/v1/admin/system/get-upload-folder-path`, { method:"GET" })
             if (response.failed) {
                 handleErr({
-                    notification: "Failed to load uplad folder path.",
+                    notification: "Failed to load upload folder path.",
                 })
                 return
             }

--- a/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
+++ b/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
@@ -90,6 +90,7 @@
                 return
             }
 
+            currentPath = response.content
         } finally {
             isSaving = false
         }

--- a/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
+++ b/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+    import { confirmDialogState } from "$lib/code/stateObjects/subState/utilStates.svelte";
+    import { formData, handleErr, safeFetch } from "$lib/code/util/codeUtil.svelte";
+    import Loader from "$lib/component/Loader.svelte";
+    import { onMount } from "svelte";
+
+    let isLoading = $state(false)
+    let isSaving = $state(false)
+
+    let currentPath: string | null = $state(null)
+    let pathInput: string | null = $derived(currentPath)
+
+    let isUnchanged = $derived((pathInput === currentPath))
+    let failedToLoad = $derived(!isLoading && !currentPath)
+
+    let placeholder = $derived.by(() => {
+        if (isLoading) return "Loading..."
+        if (failedToLoad) return "Failed to load upload folder path."
+        return "Upload folder path"
+    })
+
+    onMount(() => {
+        loadCurrentPath()
+    })
+
+    async function loadCurrentPath() {
+        if (isLoading) return
+        isLoading = true
+
+        try {
+            const response = await safeFetch(`/api/v1/admin/system/get-upload-folder-path`, { method:"GET" })
+            if (response.failed) {
+                handleErr({
+                    notification: "Failed to load uplad folder path.",
+                })
+                return
+            }
+
+            const text = response.content
+            if (response.code.failed) {
+                const json = response.json()
+                handleErr({
+                    description: "Failed to load upload folder path.",
+                    notification: `Failed to load upload folder path: ${json.message || "unknown server error."}`,
+                    isServerDown: response.code.serverDown
+                })
+                return
+            }
+
+            currentPath = text
+            pathInput = currentPath
+        } finally {
+            isLoading = false
+        }
+    }
+
+    async function changeUploadFolderPath() {
+        const conf = await confirmDialogState.show({
+            title: "Change upload folder path?",
+            message: "This will pause all uploads, and move all upload files to the new folder.",
+            cancelText: "Cancel",
+            confirmText: "Yes"
+        })
+        if (!conf) return
+
+        if (isSaving) return
+        isSaving = true
+
+        try {
+            const response = await safeFetch(`/api/v1/admin/system/set/upload-folder-path`, {
+                body: formData({ "new-path": pathInput }) 
+            })
+
+            if (response.failed) {
+                handleErr({
+                    notification: "Failed to update upload folder path.",
+                })
+                return
+            }
+
+            const status = response.code
+            const json = response.json()
+
+            if (status.failed) {
+                handleErr({
+                    description: "Failed to update upload folder path.",
+                    notification: json.message || "Failed to update upload folder path.",
+                    isServerDown: status.serverDown
+                })
+                return
+            }
+
+        } finally {
+            isSaving = false
+        }
+    }
+
+    function cancel() {
+        pathInput = currentPath
+    }
+</script>
+
+
+
+
+<div class="flex flex-col gap-4 w-full">
+    <h3 class="font-medium">Upload folder path</h3>
+    
+    <input bind:value={pathInput} class="basic-input min-w-[35rem] w-fit max-w-[min(100%,70rem)] field-sizing-content" disabled={failedToLoad} placeholder={placeholder}>
+
+    <div class="flex gap-4">
+        {#if !isSaving}
+            <button
+                on:click={changeUploadFolderPath}
+                disabled={isUnchanged || !pathInput}
+                class="basic-button bg-surface-content-button! disabled:opacity-50"
+            >
+                Save
+            </button>
+            {#if !isUnchanged}
+                <button
+                    on:click={cancel}
+                    disabled={isUnchanged}
+                    class="basic-button"
+                >
+                    Cancel
+                </button>
+            {/if}
+        {:else}
+            <div class="size-5">
+                <Loader></Loader>
+            </div>
+        {/if}
+    </div>
+</div>

--- a/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
+++ b/web/src/routes/(app)/settings/system/_setting-components/UploadFolderPathSetting.svelte
@@ -107,7 +107,7 @@
 <div class="flex flex-col gap-4 w-full">
     <h3 class="font-medium">Upload folder path</h3>
     
-    <input bind:value={pathInput} class="basic-input min-w-[35rem] w-fit max-w-[min(100%,70rem)] field-sizing-content" disabled={failedToLoad} placeholder={placeholder}>
+    <input bind:value={pathInput} class="basic-input min-w-[35rem] w-fit max-w-[min(100%,70rem)] field-sizing-content" disabled={failedToLoad || isLoading || isSaving} placeholder={placeholder}>
 
     <div class="flex gap-4">
         {#if !isSaving}


### PR DESCRIPTION
WIP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can view and update the server upload folder path from System Settings; changes migrate existing files.

* **Improvements**
  * Reduced TUS upload chunk size (5 MB → 3 MB) for more reliable uploads.
  * Stronger blocking of the data folder when disabled.
  * Safer upload concurrency handling to reduce conflicts.
  * Improved path resolution for partially missing paths.

* **UI**
  * Settings reorganized; Upload Folder setting added and Home Folder setting layout/controls refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->