### PR TITLE
Optimize file list rendering

### DIFF
--- a/web/src/lib/code/module/settings.ts
+++ b/web/src/lib/code/module/settings.ts
@@ -4,7 +4,7 @@ import { filesState } from "../stateObjects/filesState.svelte";
 import { valuesOf, includesList, keysOf } from "../util/codeUtil.svelte";
 import { getCurrentPermissions } from "./permissions";
 
-export type PreferenceSetting = "load_all_previews" | "default_page_path" | "click_to_open_file" | "preview_size_grid" | "preview_size_rows" | "file_view_type"
+export type PreferenceSetting = "load_all_previews" | "always_render_previews" | "default_page_path" | "click_to_open_file" | "preview_size_grid" | "preview_size_rows" | "file_view_type"
 
 export type SettingsSection = { name: SettingSectionId; permissions: SystemPermission[]; admin: boolean; }
 export type SettingSectionId = "preferences" | "users" | "userinfo" | "roles" | "system" | "account"
@@ -15,6 +15,11 @@ export function loadPreferenceSettings() {
     if (loadAllPreviewsStr) {
         const bool = loadAllPreviewsStr === "true"
         appState.settings.loadAllPreviews = bool
+    }
+
+    const alwaysRenderPreviewsStr = getPreferenceSetting("always_render_previews")
+    if (alwaysRenderPreviewsStr) {
+        appState.settings.alwaysRenderPreviews = alwaysRenderPreviewsStr === "true"
     }
 
     const defaultPagePath = getPreferenceSetting("default_page_path")

--- a/web/src/lib/code/stateObjects/appState.svelte.ts
+++ b/web/src/lib/code/stateObjects/appState.svelte.ts
@@ -97,6 +97,10 @@ class AppState {
 
 class SettingState {
     loadAllPreviews = $state(false)
+    /** When enabled alongside loadAllPreviews, all image entries always render their
+     *  real <img> elements instead of skeletonizing off-screen. Useful when there is
+     *  no service worker to cache headless image fetches. */
+    alwaysRenderPreviews = $state(false)
 	defaultPagePath = $state<keyof typeof filePagePaths>("/files")
     clickToOpenFile = $state(false)
     previewSize = $state({ rows: 2, grid: 2 })

--- a/web/src/lib/code/stateObjects/filesState.svelte.ts
+++ b/web/src/lib/code/stateObjects/filesState.svelte.ts
@@ -3,7 +3,7 @@ import type { FullFileMetadata } from "$lib/code/auth/types"
 import { uiState } from "$lib/code/stateObjects/uiState.svelte"
 import { filenameFromPath, generateRandomNumber, isFolder, keysOf, prependIfMissing, printStack, removeString, sortArrayAlphabetically, sortArrayByNumber, sortArrayByNumberDesc, sortFileMetadata, valuesOf } from "$lib/code/util/codeUtil.svelte"
 import { SvelteSet } from "svelte/reactivity"
-import { ImageLoadQueue } from "../../../routes/(app)/(files)/files/[...path]/_code/fileBrowserUtil"
+import { VisibilityManager } from "../../../routes/(app)/(files)/files/[...path]/_code/fileBrowserUtil.svelte"
 import { SingleChildBooleanTree } from "../../../routes/(app)/(files)/files/[...path]/_code/fileUtilities"
 import { getFileCategoryFromFilename, type FileCategory } from "../data/files"
 import { fileSortingDirections, fileSortingModes, type FileSortingMode, type SortingDirection } from "../types/fileTypes"
@@ -295,7 +295,7 @@ class FileUiStateClasss {
      */
     fileSortingMenuPopoverOpen = $state(false)
 
-    filePreviewLoader = $state(new ImageLoadQueue())
+    visibilityManager = $state(new VisibilityManager())
 
     toggleSidebar() {
         this.detailsOpen = !this.detailsOpen

--- a/web/src/routes/(app)/(files)/files/[...path]/+page.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/+page.svelte
@@ -33,7 +33,7 @@
     import SharedFileScopeSwitchPopover from "./_elements/button/SharedFileScopeSwitchPopover.svelte";
     import FileSearchButton from "./_elements/button/FileSearchButton.svelte";
     import CloseIcon from "$lib/component/icons/CloseIcon.svelte";
-    import { openEntry } from "./_code/fileBrowserUtil";
+    import { openEntry } from "./_code/fileBrowserUtil.svelte";
     import OpenFileAsCategoryButton from "./_elements/button/OpenFileAsCategoryButton.svelte";
     import { confirmDialogState } from "$lib/code/stateObjects/subState/utilStates.svelte";
     import ArrowLeftIcon from "$lib/component/icons/ArrowLeftIcon.svelte";
@@ -64,7 +64,6 @@
 
     onMount(() => {
         window.addEventListener('keydown', handleKeyDown)
-        filesState.ui.filePreviewLoader.setScrollContainer(filesState.scroll.container || null)
 
         // Automatically refresh folder entries
         pollingInterval = dynamicInterval(() => {
@@ -74,6 +73,12 @@
         return () => {
             window.removeEventListener('keydown', handleKeyDown)
             pollingInterval?.cancel()
+        }
+    })
+
+    $effect(() => {
+        if (filesState.scroll.container) {
+            filesState.ui.visibilityManager.setScrollContainer(filesState.scroll.container)
         }
     })
 

--- a/web/src/routes/(app)/(files)/files/[...path]/_code/fileBrowserUtil.svelte.ts
+++ b/web/src/routes/(app)/(files)/files/[...path]/_code/fileBrowserUtil.svelte.ts
@@ -1,8 +1,11 @@
 import { goto } from "$app/navigation"
 import type { FileMetadata, FullFileMetadata } from "$lib/code/auth/types"
 import type { GridPreviewSize, RowPreviewSize } from "$lib/code/config/values"
+import { getFileCategoryFromFilename } from "$lib/code/data/files"
 import { appState } from "$lib/code/stateObjects/appState.svelte"
 import { filesState } from "$lib/code/stateObjects/filesState.svelte"
+import { filenameFromPath } from "$lib/code/util/codeUtil.svelte"
+import { SvelteSet } from "svelte/reactivity"
 
 export type FileContextMenuProps = {
     option_rename: (entry: FileMetadata) => any
@@ -47,92 +50,190 @@ export function changeSortingMode(mode: typeof filesState.sortingMode) {
     }
 }
 
-export class ImageLoadQueue {
-    // Target element for IntersectionObserver root (defaults to viewport if null)
+export class VisibilityManager {
     private scrollContainer: HTMLElement | null = null
-    
-    // Single unified observer for detecting visibility
     private observer: IntersectionObserver | null = null
     
-    // Queue management sets
-    private pending: Set<HTMLImageElement> = new Set() // Registered but not loaded
-    private highPriority: Set<HTMLImageElement> = new Set() // Currently in viewport
-    private lowPriority: Set<HTMLImageElement> = new Set() // Close to viewport
-    private loading: Set<HTMLImageElement> = new Set() // Currently fetching
+    private pending: Set<HTMLImageElement> = new Set()
+    private highPriority: Set<HTMLImageElement> = new Set()
+    private lowPriority: Set<HTMLImageElement> = new Set()
+    private loading: Set<HTMLImageElement> = new Set()
     
-    // Map to link file paths to image elements for data-driven sorting
     private imageMap = new Map<string, HTMLImageElement>()
     private nodeToPath = new WeakMap<HTMLImageElement, string>()
+    /** Tracks headless (offscreen) images created for loadAllPreviews preloading */
+    private headlessImages = new Set<HTMLImageElement>()
 
-    // RAF-based debouncing (replaces queueMicrotask for frame-aligned processing)
     private rafId: number | null = null
     
-    private concurrency = 2 // Max simultaneous downloads
-    private loadDistance = 500 // Pixel margin for "nearby" detection
-    
-    // Threshold to distinguish "in viewport" from "nearby" based on intersection ratio
-    // Elements with ratio >= this value are considered high priority (visible)
+    /** Tracks entry paths that have been observed at least once, to distinguish first mount from re-registration */
+    private knownEntryPaths = new Set<string>()
+
+    private concurrency = 2
+    private renderDistance = 500
+    private imageLoadDistance = 300
     private visibilityThreshold = 0.01
 
+    visibleEntryPaths = new SvelteSet<string>()
+    private entryElements = new Map<HTMLElement, string>()
 
-    // Sets the scroll container and resets observers to use the new root
+
     setScrollContainer(container: HTMLElement | null) {
         this.scrollContainer = container
         this.reinitObserver()
     }
 
     private initObserver() {
-        // Single observer with extended rootMargin and multiple thresholds
-        // This replaces the previous two-observer approach
         this.observer = new IntersectionObserver(
             (entries) => {
                 for (const entry of entries) {
-                    const img = entry.target as HTMLImageElement
-                    
-                    if (entry.isIntersecting) {
-                        // Determine priority based on intersection ratio
-                        // High ratio = actually visible in viewport
-                        // Low ratio = just entering the extended margin
-                        if (entry.intersectionRatio >= this.visibilityThreshold) {
-                            this.highPriority.add(img)
-                            this.lowPriority.delete(img)
-                        } else {
-                            // Only add to low priority if not already high priority
-                            if (!this.highPriority.has(img)) {
-                                this.lowPriority.add(img)
-                            }
-                        }
+                    if (entry.target instanceof HTMLImageElement) {
+                        this.handleImageIntersect(entry)
                     } else {
-                        // Element left the extended margin entirely
-                        this.highPriority.delete(img)
-                        this.lowPriority.delete(img)
+                        this.handleEntryIntersect(entry)
                     }
                 }
-                this.scheduleProcess()
+                this.scheduleImageLoad()
             },
             { 
                 root: this.scrollContainer,
-                rootMargin: `${this.loadDistance}px`,
-                // Multiple thresholds: 0 for entering margin, visibilityThreshold for actual viewport
+                rootMargin: `${this.renderDistance}px`,
                 threshold: [0, this.visibilityThreshold, 0.5, 1.0]
             }
         )
     }
 
-    // Restarts observer (e.g., when container changes) and re-observes pending images
+    private handleEntryIntersect(entry: IntersectionObserverEntry) {
+        const element = entry.target as HTMLElement
+        const path = this.entryElements.get(element)
+        if (!path) return
+        
+        if (entry.isIntersecting) {
+            this.visibleEntryPaths.add(path)
+        } else {
+            this.visibleEntryPaths.delete(path)
+        }
+    }
+
+    private handleImageIntersect(entry: IntersectionObserverEntry) {
+        const img = entry.target as HTMLImageElement
+        
+        if (entry.isIntersecting) {
+            const distance = this.getDistanceFromViewport(entry.boundingClientRect)
+            
+            if (distance <= this.imageLoadDistance) {
+                this.highPriority.add(img)
+                this.lowPriority.delete(img)
+            } else {
+                if (!this.highPriority.has(img)) {
+                    this.lowPriority.add(img)
+                }
+            }
+        } else {
+            this.highPriority.delete(img)
+            this.lowPriority.delete(img)
+        }
+    }
+
+    private getDistanceFromViewport(rect: DOMRectReadOnly): number {
+        if (!this.scrollContainer) {
+            return rect.top < 0 ? -rect.top : 
+                   rect.bottom > window.innerHeight ? rect.bottom - window.innerHeight : 0
+        }
+        
+        const containerRect = this.scrollContainer.getBoundingClientRect()
+        const top = rect.top - containerRect.top
+        const bottom = rect.bottom - containerRect.bottom
+        
+        if (top < 0) return -top
+        if (bottom > 0) return bottom
+        return 0
+    }
+
     private reinitObserver() {
         this.observer?.disconnect()
         this.highPriority.clear()
         this.lowPriority.clear()
+        this.visibleEntryPaths.clear()
+        this.knownEntryPaths.clear()
         
         this.initObserver()
         
         for (const img of this.pending) {
             this.observer?.observe(img)
         }
+        for (const [element] of this.entryElements) {
+            this.observer?.observe(element)
+        }
     }
 
-    // Registers an image to be managed by the queue
+    observeEntry = (node: HTMLElement, path: string) => {
+        if (!this.observer) {
+            this.initObserver()
+        }
+        
+        this.entryElements.set(node, path)
+        this.knownEntryPaths.add(path)
+        this.visibleEntryPaths.add(path)
+        this.observer!.observe(node)
+        
+        return {
+            update: (newPath: string) => {
+                const oldPath = this.entryElements.get(node)
+                if (oldPath && oldPath !== newPath) {
+                    this.visibleEntryPaths.delete(oldPath)
+                }
+                this.entryElements.set(node, newPath)
+                this.visibleEntryPaths.add(newPath)
+            },
+            destroy: () => {
+                this.observer?.unobserve(node)
+                this.entryElements.delete(node)
+            }
+        }
+    }
+
+    /**
+     * Svelte action for skeleton/placeholder elements.
+     * On first mount (path never seen before), eagerly marks as visible to avoid a flash of skeleton.
+     * On re-registration (path was visible, then scrolled away), does NOT eagerly add,
+     * allowing the IntersectionObserver to determine visibility naturally and preventing infinite loops.
+     */
+    observeSkeleton = (node: HTMLElement, path: string) => {
+        if (!this.observer) {
+            this.initObserver()
+        }
+
+        this.entryElements.set(node, path)
+
+        // First time this path is ever observed: eagerly mark visible (same as observeEntry)
+        // Re-registration after element swap: let IntersectionObserver decide
+        if (!this.knownEntryPaths.has(path)) {
+            this.knownEntryPaths.add(path)
+            this.visibleEntryPaths.add(path)
+        }
+
+        this.observer!.observe(node)
+
+        return {
+            update: (newPath: string) => {
+                const oldPath = this.entryElements.get(node)
+                if (oldPath && oldPath !== newPath) {
+                    this.visibleEntryPaths.delete(oldPath)
+                }
+                this.entryElements.set(node, newPath)
+                if (!this.knownEntryPaths.has(newPath)) {
+                    this.knownEntryPaths.add(newPath)
+                    this.visibleEntryPaths.add(newPath)
+                }
+            },
+            destroy: () => {
+                this.observer?.unobserve(node)
+                this.entryElements.delete(node)
+            }
+        }
+    }
+
     register(img: HTMLImageElement, path?: string) {
         if (!img.hasAttribute(`data-src`)) return
 
@@ -140,16 +241,22 @@ export class ImageLoadQueue {
             this.initObserver()
         }
 
-        this.pending.add(img)
+        // If there's an existing headless image for this path, clean it up
         if (path) {
+            const existing = this.imageMap.get(path)
+            if (existing && existing !== img && this.headlessImages.has(existing)) {
+                this.pending.delete(existing)
+                this.headlessImages.delete(existing)
+                this.nodeToPath.delete(existing)
+            }
             this.imageMap.set(path, img)
             this.nodeToPath.set(img, path)
         }
 
+        this.pending.add(img)
+
         this.observer!.observe(img)
-        
-        // Trigger process in case we are in loadAllPreviews mode or slots are open
-        this.scheduleProcess() 
+        this.scheduleImageLoad() 
     }
 
     // Sorts the pending queue to match the given list of file paths
@@ -175,27 +282,80 @@ export class ImageLoadQueue {
         // No need to trigger process() here as the queue size didn't change
     }
 
-    // Cleans up an image from all queues and observers
+    /**
+     * Pre-registers headless (offscreen) images for all image/video entries so that
+     * loadAllPreviews can fetch them even when their grid entries are in skeleton state.
+     * The images are added to the pending queue without being observed by IntersectionObserver.
+     * When an entry later scrolls into view and mounts a real FileThumbnail <img>,
+     * the headless image is replaced and the browser serves the data from the service worker cache.
+     */
+    preloadAllPreviews(entries: FullFileMetadata[], pixelSize: number) {
+        const shareTokenParam = filesState.getIsShared() ? `&shareToken=${filesState.meta.shareToken}` : ``
+
+        let added = false
+        for (const entry of entries) {
+            // Skip entries that already have a registered image (real or headless)
+            if (this.imageMap.has(entry.path)) continue
+
+            const format = getFileCategoryFromFilename(entry.filename || filenameFromPath(entry.path))
+            if (format !== `image` && format !== `video`) continue
+
+            const endpoint = format === `image` ? `image-thumbnail` : `video-preview`
+            const src = `/api/v1/file/${endpoint}?size=${pixelSize}&path=${encodeURIComponent(entry.path)}&modified=${entry.modifiedDate}${shareTokenParam}`
+
+            const img = document.createElement(`img`)
+            img.setAttribute(`data-src`, src)
+
+            this.headlessImages.add(img)
+            this.pending.add(img)
+            this.imageMap.set(entry.path, img)
+            this.nodeToPath.set(img, entry.path)
+            added = true
+        }
+
+        if (added) {
+            this.scheduleImageLoad()
+        }
+    }
+
+    // Cleans up an image from all queues and observers.
+    // When loadAllPreviews is enabled and a real (non-headless) image is unregistered
+    // (e.g. entry went back to skeleton), a headless replacement is created so the
+    // thumbnail still gets fetched and cached by the service worker.
     unregister(img: HTMLImageElement) {
+        const wasHeadless = this.headlessImages.has(img)
+        const wasInPending = this.pending.has(img)
+        const dataSrc = img.getAttribute(`data-src`)
+
         this.pending.delete(img)
         this.highPriority.delete(img)
         this.lowPriority.delete(img)
+        this.headlessImages.delete(img)
         this.observer?.unobserve(img)
         
         const path = this.nodeToPath.get(img)
         if (path) {
             this.imageMap.delete(path)
             this.nodeToPath.delete(img)
+
+            // If a real image is being unregistered (entry went to skeleton) and it was
+            // still pending (never started loading), create a headless replacement so that
+            // loadAllPreviews can still fetch and cache the thumbnail via the service worker.
+            if (!wasHeadless && wasInPending && dataSrc && appState.settings.loadAllPreviews) {
+                const headless = document.createElement(`img`)
+                headless.setAttribute(`data-src`, dataSrc)
+                this.headlessImages.add(headless)
+                this.pending.add(headless)
+                this.imageMap.set(path, headless)
+                this.nodeToPath.set(headless, path)
+                this.scheduleImageLoad()
+            }
         }
     }
 
-    // RAF-based debounced trigger for the processing loop
-    // Using requestAnimationFrame instead of queueMicrotask prevents forced reflows
-    // by ensuring processing happens at the optimal time in the frame lifecycle
-    private scheduleProcess() {
+    private scheduleImageLoad() {
         if (this.rafId !== null) return
         
-        // setTimeout runs even when the tab is not focused
         this.rafId = setTimeout(() => {
             this.rafId = null
             this.runProcessLoop()
@@ -266,7 +426,7 @@ export class ImageLoadQueue {
             img.onload = null
             img.onerror = null
             this.loading.delete(img)
-            this.scheduleProcess() // Trigger next item in queue
+            this.scheduleImageLoad()
         }
 
         img.onload = cleanup
@@ -315,6 +475,8 @@ export class ImageLoadQueue {
         this.lowPriority.clear()
         this.loading.clear()
         this.imageMap.clear()
+        this.headlessImages.clear()
+        this.knownEntryPaths.clear()
     }
 }
 

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/FileBrowser.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/FileBrowser.svelte
@@ -11,7 +11,7 @@
     import { appState } from '$lib/code/stateObjects/appState.svelte'
     import { isDialogOpen } from "$lib/code/util/stateUtils"
     import { textFileViewerState } from "../../_code/textFileViewerState.svelte"
-    import { openEntry, selectSiblingFile, scrollSelectedEntryIntoView } from "../../_code/fileBrowserUtil";
+    import { openEntry, selectSiblingFile, scrollSelectedEntryIntoView } from "../../_code/fileBrowserUtil.svelte";
     import FileList from "./FileList.svelte";
     import Loader from "$lib/component/Loader.svelte";
 
@@ -31,7 +31,7 @@
         return () => {
             // Clean up listener when component unmounts
             window.removeEventListener('keydown', handleKeyDown)
-            filesState.ui.filePreviewLoader.destroy()
+            filesState.ui.visibilityManager.destroy()
         }
     })
 

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/FileList.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/FileList.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
     import type { FullFileMetadata } from "$lib/code/auth/types";
     import { type RowPreviewSize, type GridPreviewSize, config } from "$lib/code/config/values";
+    import { appState } from "$lib/code/stateObjects/appState.svelte";
     import { filesState } from "$lib/code/stateObjects/filesState.svelte";
     import { explicitEffect } from "$lib/code/util/codeUtil.svelte";
-    import { changeSortingMode, type FileListProps } from "../../_code/fileBrowserUtil";
+    import { changeSortingMode, type FileListProps } from "../../_code/fileBrowserUtil.svelte";
     import FileContextMenuPopover from "../ui/FileContextMenuPopover.svelte";
     import GridFileEntry from "./GridFileEntry.svelte";
     import RowFileEntry from "./RowFileEntry.svelte";
@@ -42,7 +43,15 @@
     explicitEffect(() => [sortedEntries], () => {
         const paths = sortedEntries?.map(e => e.path) || []
         
-        filesState.ui.filePreviewLoader.reorderQueue(paths)
+        filesState.ui.visibilityManager.reorderQueue(paths)
+    })
+
+    // Pre-register headless images for all entries when loadAllPreviews is enabled,
+    // so skeleton entries that are never rendered still get their thumbnails fetched
+    explicitEffect(() => [sortedEntries, appState.settings.loadAllPreviews, filesState.ui.previewSize], () => {
+        if (!appState.settings.loadAllPreviews || !sortedEntries) return
+        const size = filesState.ui.previewSize as GridPreviewSize
+        filesState.ui.visibilityManager.preloadAllPreviews(sortedEntries, size.pixelSize)
     })
 
     function closeContextMenu() {

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/FileThumbnail.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/FileThumbnail.svelte
@@ -19,7 +19,7 @@
         isLarge: boolean,
     } = $props()
 
-    const loadFilePreview = filesState.ui.filePreviewLoader.getAction()
+    const loadFilePreview = filesState.ui.visibilityManager.getAction()
 
     const format = getFileCategoryFromFilename(entry.filename || filenameFromPath(entry.path))
     const shareTokenParam = filesState.getIsShared() ? `&shareToken=${filesState.meta.shareToken}` : ``

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/GridFileEntry.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/GridFileEntry.svelte
@@ -3,7 +3,7 @@
     import { isFolder } from "$lib/code/util/codeUtil.svelte";
     import ThreeDotsIcon from "$lib/component/icons/ThreeDotsIcon.svelte";
     import { onMount } from "svelte";
-    import type { FileEntryProps } from "../../_code/fileBrowserUtil";
+    import type { FileEntryProps } from "../../_code/fileBrowserUtil.svelte";
     import FileThumbnail from "./FileThumbnail.svelte";
     import type { GridPreviewSize } from "$lib/code/config/values";
     import { appState } from "$lib/code/stateObjects/appState.svelte";
@@ -33,71 +33,81 @@
     let isSelected = $derived(!!entry && filesState.selectedEntries.currentSet.has(entry.path))
     
     let isUnopenable = $derived(!entry || (isFolder(entry) && !entry.isExecutable) || (entry.isSymlink && !appState.followSymlinks))
+
+    let isVisible = $derived(appState.settings.alwaysRenderPreviews || filesState.ui.visibilityManager.visibleEntryPaths.has(entry.path))
+    
+    const observeEntry = filesState.ui.visibilityManager.observeEntry
+    const observeSkeleton = filesState.ui.visibilityManager.observeSkeleton
 </script>
 
-
-<a
-    on:click|preventDefault={(e) => entryOnClick(e, entry)}
-    on:contextmenu={(e) => { entryOnContextMenu(e, entry) }}
-    draggable={entry.permissions?.includes("MOVE")}
-    data-entry-path={entry.path} rel="noopener noreferrer"
-    style:--entry-height="{size.height}rem"
-    class="
-        grid-file-entry w-full min-w-0 flex flex-col items-center select-none group rounded-lg outline-0
-        {isUnopenable 
-            ? 'cursor-default' 
-            : 'cursor-pointer'
-        }
-        {isUnopenable 
-            ? isSelected ? 'bg-blue-200 dark:bg-sky-950' : 'hover:bg-neutral-200 dark:hover:bg-neutral-800'
-            : isSelected ? 'bg-blue-200/60 dark:bg-sky-950/60' : 'bg-neutral-200/30 dark:bg-neutral-800/30 hover:bg-neutral-200/60 dark:hover:bg-neutral-800/60'
-        }
-    "
-    href={encodeURI(`${filesState.meta.pagePath}${(entry.path)}`)}
-    on:dragstart={(e) => { event_dragStart(e, entry) }}
-    on:dragover={(e) => { event_dragOver(e, entry) }}
-    on:dragleave={(e) => { event_dragLeave(e, entry) }}
-    on:drop={(e) => { event_drop(e, entry) }}
-    on:dragend={(e) => { event_dragEnd(e, entry) }}
->
-    <!-- Icon / preview and checkbox -->
-    <div class="entry-preview relative flex flex-col w-full">
-        <!-- Preview image -->
-        <div class="h-full fill-neutral-500 stroke-neutral-500 shrink-0 flex items-center justify-center pointer-events-none">
-            {#if entry.filename}
-                <FileThumbnail {entry} size={size.pixelSize} isLarge={true}></FileThumbnail>
-            {/if}
-        </div>
-
-        <!-- Selection Checkbox -->
-        {#key isSelected}
-            <div on:click|stopPropagation|preventDefault={() => { onClickSelectCheckbox(entry.path) }} class="absolute top-0 left-0 flex items-center justify-center">
-                <input checked={isSelected} class="!size-5 lg:opacity-0 checked:opacity-100 group-hover:opacity-100" type="checkbox">
+{#if isVisible}
+    <a
+        on:click|preventDefault={(e) => entryOnClick(e, entry)}
+        on:contextmenu={(e) => { entryOnContextMenu(e, entry) }}
+        draggable={entry.permissions?.includes("MOVE")}
+        data-entry-path={entry.path} rel="noopener noreferrer"
+        style:--entry-height="{size.height}rem"
+        class="
+            grid-file-entry w-full min-w-0 flex flex-col items-center select-none group rounded-lg outline-0
+            {isUnopenable 
+                ? 'cursor-default' 
+                : 'cursor-pointer'
+            }
+            {isUnopenable 
+                ? isSelected ? 'bg-blue-200 dark:bg-sky-950' : 'hover:bg-neutral-200 dark:hover:bg-neutral-800'
+                : isSelected ? 'bg-blue-200/60 dark:bg-sky-950/60' : 'bg-neutral-200/30 dark:bg-neutral-800/30 hover:bg-neutral-200/60 dark:hover:bg-neutral-800/60'
+            }
+        "
+        href={encodeURI(`${filesState.meta.pagePath}${(entry.path)}`)}
+        on:dragstart={(e) => { event_dragStart(e, entry) }}
+        on:dragover={(e) => { event_dragOver(e, entry) }}
+        on:dragleave={(e) => { event_dragLeave(e, entry) }}
+        on:drop={(e) => { event_drop(e, entry) }}
+        on:dragend={(e) => { event_dragEnd(e, entry) }}
+        use:observeEntry={entry.path}
+    >
+        <div class="entry-preview relative flex flex-col w-full">
+            <div class="h-full fill-neutral-500 stroke-neutral-500 shrink-0 flex items-center justify-center pointer-events-none">
+                {#if entry.filename}
+                    <FileThumbnail {entry} size={size.pixelSize} isLarge={true}></FileThumbnail>
+                {/if}
             </div>
-        {/key}
-    </div>
 
-    <!-- Filename + Icon -->
-    <div class="entry-bar w-full flex items-end justify-between overflow-hidden">
-        <div class="flex gap-2 min-w-0 overflow-hidden whitespace-nowrap text-ellipsis">
-            <p title={entry.filename} class="truncate">
-                {entry.filename!}
-            </p>
+            {#key isSelected}
+                <div on:click|stopPropagation|preventDefault={() => { onClickSelectCheckbox(entry.path) }} class="absolute top-0 left-0 flex items-center justify-center">
+                    <input checked={isSelected} class="!size-5 lg:opacity-0 checked:opacity-100 group-hover:opacity-100" type="checkbox">
+                </div>
+            {/key}
         </div>
 
-        <!-- Menu button -->
-        <button
-            on:click|stopPropagation|preventDefault={(e) => { entryMenuOnClick(e.currentTarget, entry) }}
-            class="h-[1.5rem] aspect-square flex items-center justify-center rounded-full p-[0.20rem] hover:bg-neutral-400/30 dark:hover:bg-neutral-600/50 fill-neutral-700 dark:fill-neutral-500"
-        >
-            <ThreeDotsIcon />
-        </button>
+        <div class="entry-bar w-full flex items-end justify-between overflow-hidden">
+            <div class="flex gap-2 min-w-0 overflow-hidden whitespace-nowrap text-ellipsis">
+                <p title={entry.filename} class="truncate">
+                    {entry.filename!}
+                </p>
+            </div>
+
+            <button
+                on:click|stopPropagation|preventDefault={(e) => { entryMenuOnClick(e.currentTarget, entry) }}
+                class="h-[1.5rem] aspect-square flex items-center justify-center rounded-full p-[0.20rem] hover:bg-neutral-400/30 dark:hover:bg-neutral-600/50 fill-neutral-700 dark:fill-neutral-500"
+            >
+                <ThreeDotsIcon />
+            </button>
+        </div>
+    </a>
+{:else}
+    <div
+        data-entry-path={entry.path}
+        style:--entry-height="{size.height}rem"
+        class="grid-file-entry w-full min-w-0 rounded-lg"
+        use:observeSkeleton={entry.path}
+    >
+        <span class="skeleton-filename">{entry.filename}</span>
     </div>
-</a>
+{/if}
 
 
 <style>
-    /* Config */
     .grid-file-entry {
         --entry-height: 7rem;
         --entry-padding: 0.5rem;
@@ -107,18 +117,24 @@
         --entry-bar-height: 2rem;
         --entry-preview-height: calc(var(--entry-free-height) - var(--entry-bar-height));
 
-        /* Entry Styling */
-        /* width: 9rem;
-        max-width: 11rem; */
         height: var(--entry-height);
         padding: var(--entry-padding);
     }
 
-    /* Elements */
     .entry-bar {
         height: var(--entry-bar-height);
     }
     .entry-preview {
         height: var(--entry-preview-height);
+    }
+
+    .skeleton-filename {
+        font-size: 1px;
+        line-height: 0;
+        color: transparent;
+        display: block;
+        overflow: hidden;
+        height: 0;
+        width: 0;
     }
 </style>

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/RowFileEntry.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/FileBrowser/RowFileEntry.svelte
@@ -3,7 +3,7 @@
     import { formatBytesRounded, formatUnixMillis, isFolder } from "$lib/code/util/codeUtil.svelte";
     import ThreeDotsIcon from "$lib/component/icons/ThreeDotsIcon.svelte";
     import { onMount } from "svelte";
-    import type { FileEntryProps } from "../../_code/fileBrowserUtil";
+    import type { FileEntryProps } from "../../_code/fileBrowserUtil.svelte";
     import FileThumbnail from "./FileThumbnail.svelte";
     import type { RowPreviewSize } from "$lib/code/config/values";
     import { appState } from "$lib/code/stateObjects/appState.svelte";
@@ -32,9 +32,15 @@
     let isSelected = $derived(!!entry && filesState.selectedEntries.currentSet.has(entry.path))
     
     let isUnopenable = $derived(!entry || (isFolder(entry) && !entry.isExecutable) || (entry.isSymlink && !appState.followSymlinks))
+
+    let isVisible = $derived(appState.settings.alwaysRenderPreviews || filesState.ui.visibilityManager.visibleEntryPaths.has(entry.path))
+
+    const observeEntry = filesState.ui.visibilityManager.observeEntry
+    const observeSkeleton = filesState.ui.visibilityManager.observeSkeleton
 </script>
 
 
+{#if isVisible}
 <a
     on:click|preventDefault={(e) => entryOnClick(e, entry)}
     on:contextmenu={(e) => { entryOnContextMenu(e, entry) }}
@@ -59,6 +65,7 @@
     on:dragleave={(e) => { event_dragLeave(e, entry) }}
     on:drop={(e) => { event_drop(e, entry) }}
     on:dragend={(e) => { event_dragEnd(e, entry) }}
+    use:observeEntry={entry.path}
 >
     <!-- Filename + Icon -->
     <div class="h-full flex items-center min-h-0">
@@ -100,3 +107,26 @@
         </button>
     </div>
 </a>
+{:else}
+    <div
+        data-entry-path={entry.path}
+        style="height: {size.height}rem;"
+        class="file-row-grid gap-x-2 items-center py-1 pl-2 pr-1"
+        use:observeSkeleton={entry.path}
+    >
+        <span class="row-skeleton-filename">{entry.filename}</span>
+    </div>
+{/if}
+
+
+<style>
+    .row-skeleton-filename {
+        font-size: 1px;
+        line-height: 0;
+        color: transparent;
+        display: block;
+        overflow: hidden;
+        height: 0;
+        width: 0;
+    }
+</style>

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/layout/Breadcrumbs.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/layout/Breadcrumbs.svelte
@@ -5,7 +5,7 @@
     import InfoIcon from '$lib/component/icons/InfoIcon.svelte'
     import { calculateTextWidth } from "$lib/code/util/uiUtil"
     import { breadcrumbState, type Segment } from '../../_code/breadcrumbState.svelte'
-    import { openEntry } from '../../_code/fileBrowserUtil';
+    import { openEntry } from '../../_code/fileBrowserUtil.svelte';
 
     // Context menu for breadcrumb buttons
     let contextMenuButton: HTMLButtonElement | null = $state(null)

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/layout/FileViewer.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/layout/FileViewer.svelte
@@ -13,7 +13,7 @@
     import type Player from "video.js/dist/types/player";
     import mime from 'mime'
     import { textFileViewerState } from "../../_code/textFileViewerState.svelte";
-    import { selectSiblingFile } from "../../_code/fileBrowserUtil";
+    import { selectSiblingFile } from "../../_code/fileBrowserUtil.svelte";
     import OpenFileAsCategoryButton from "../button/OpenFileAsCategoryButton.svelte";
     import FileNavZone from "../ui/FileNavZone.svelte";
     

--- a/web/src/routes/(app)/(files)/files/[...path]/_elements/ui/FileContextMenuPopover.svelte
+++ b/web/src/routes/(app)/(files)/files/[...path]/_elements/ui/FileContextMenuPopover.svelte
@@ -16,7 +16,7 @@
     import NewTabIcon from "$lib/component/icons/NewTabIcon.svelte";
     import TrashIcon from "$lib/component/icons/TrashIcon.svelte";
     import { option_downloadSelectedFiles } from "../../_code/fileActions";
-    import type { FileContextMenuProps } from "../../_code/fileBrowserUtil";
+    import type { FileContextMenuProps } from "../../_code/fileBrowserUtil.svelte";
 
     let {
         entryMenuButton,

--- a/web/src/routes/(app)/settings/preferences/_setting-components/LoadPreviewsSetting.svelte
+++ b/web/src/routes/(app)/settings/preferences/_setting-components/LoadPreviewsSetting.svelte
@@ -6,6 +6,16 @@
         const bool = !appState.settings.loadAllPreviews
         appState.settings.loadAllPreviews = bool
         setPreferenceSetting("load_all_previews", bool)
+        if (!bool) {
+            appState.settings.alwaysRenderPreviews = false
+            setPreferenceSetting("always_render_previews", false)
+        }
+    }
+
+    function toggleAlwaysRender() {
+        const bool = !appState.settings.alwaysRenderPreviews
+        appState.settings.alwaysRenderPreviews = bool
+        setPreferenceSetting("always_render_previews", bool)
     }
 </script>
 
@@ -31,4 +41,25 @@
         class="mt-2 w-fit px-4 py-2 bg-surface-content-button rounded-md">
         {appState.settings.loadAllPreviews ? 'Disable' : 'Enable'}
     </button>
+
+    {#if appState.settings.loadAllPreviews}
+        <div class="flex flex-col gap-2 mt-2 pl-4 border-l-2 border-neutral-300 dark:border-neutral-700">
+            <h4 class="font-medium">Always Render Previews</h4>
+            <div class="flex items-center gap-2 my-1">
+                <div class={`w-3 h-3 rounded-full ${appState.settings.alwaysRenderPreviews ? 'bg-green-500' : 'bg-neutral-500'}`}></div>
+                <p class="text-base font-medium">
+                    {appState.settings.alwaysRenderPreviews ? 'Enabled' : 'Disabled'}
+                </p>
+            </div>
+            <p class="text-sm text-neutral-600 dark:text-neutral-400">
+                Keep all image previews rendered at all times instead of unloading them when off-screen.<br>
+                Enable in case of issues with preview caching or loading problems.
+            </p>
+            <button
+                on:click={toggleAlwaysRender}
+                class="mt-2 w-fit px-4 py-2 bg-surface-content-button rounded-md">
+                {appState.settings.alwaysRenderPreviews ? 'Disable' : 'Enable'}
+            </button>
+        </div>
+    {/if}
 </div>


### PR DESCRIPTION
Render only skeleton elements for file entries outside of viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Always Render Previews" preference setting that works with "Load All Previews" to render all image previews as real elements instead of placeholders.

* **Improvements**
  * Enhanced preview loading system with visibility-based rendering and skeleton placeholders for better performance.
  * Dependent setting logic: disabling "Load All Previews" automatically disables "Always Render Previews" to prevent inconsistent states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->